### PR TITLE
feat: override DISCOVERY_REPOSITORY.

### DIFF
--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -10,8 +10,8 @@ ARG APP_USER_ID=1000
 RUN useradd --home-dir /openedx --create-home --shell /bin/bash --uid ${APP_USER_ID} app
 USER ${APP_USER_ID}
 
-ARG DISCOVERY_REPOSITORY=https://github.com/edx/course-discovery.git
-ARG DISCOVERY_VERSION={{ OPENEDX_COMMON_VERSION }}
+ARG DISCOVERY_REPOSITORY={{ DISCOVERY_REPOSITORY }}
+ARG DISCOVERY_VERSION={{ DISCOVERY_VERSION }}
 RUN mkdir -p /openedx/discovery && \
     git clone $DISCOVERY_REPOSITORY --branch $DISCOVERY_VERSION --depth 1 /openedx/discovery
 WORKDIR /openedx/discovery


### PR DESCRIPTION
## Description

Even though the default value of each argument can be overridden by using the `--build-arg` flag in the `docker build` command, we are not passing any arguments in our `tutor-build-image-action`. You can see it [here](https://github.com/Pearson-Advance/tutor-build-image-action/blob/45d31df2a2cf6512571679393bf24371e6dce802/action.yml#L196-L202). However, this PR proposes to edit the Dockerfile in order to override the ARGs mentioned below:

```
ARG DISCOVERY_REPOSITORY=https://github.com/edx/course-discovery.git
ARG DISCOVERY_VERSION={{ OPENEDX_COMMON_VERSION }}
```

We aim to stick to the idea of having a single source of truth and avoid adding these variables as inputs or environment variables in the GitHub Actions workflow. Instead, we will use the variables defined by our `tutor-pearson-plugin`, which you can find [here](https://github.com/Pearson-Advance/tutor-pearson-plugin/blob/5cc8f49592859d26d11cb00c816a0a43f8baab0b/tutor_pearson_plugin/services/discovery/defaults.py#L8-L10).