### PR TITLE
PADV-2771 - Set UWSGI buffer-size from Tutor config.

### DIFF
--- a/tutordiscovery/plugin.py
+++ b/tutordiscovery/plugin.py
@@ -28,6 +28,7 @@ config = {
         "OAUTH2_KEY_SSO": "discovery-sso",
         "OAUTH2_KEY_SSO_DEV": "discovery-sso-dev",
         "CACHE_REDIS_DB": "{{ OPENEDX_CACHE_REDIS_DB }}",
+        "UWSGI_BUFFER_SIZE": "8192",
     },
 }
 

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -65,5 +65,5 @@ CMD uwsgi \
     --single-interpreter \
     --enable-threads \
     --processes=2 \
-    --buffer-size=8192 \
+    --buffer-size={{ DISCOVERY_UWSGI_BUFFER_SIZE }} \
     --wsgi-file course_discovery/wsgi.py


### PR DESCRIPTION
## Description:

This PR adds the capability to set the [buffer-size](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size) for the UWSGI process in the Discovery image.

## Test:

- With Discovery Tutor plugin enabled, run tutor config save.
- The rendered Dockerfile: env/plugins/discovery/build/discovery/Dockerfile should have the default value of 8192.
- Add DISCOVERY_UWSGI_BUFFER_SIZE to the config.yaml with another value, e.i 20000.
- Run tutor config save and the Dockerfile should now have the value set from the config.yaml.
- Run tutor images build discovery and the image should be built without any errors.
- Run tutor config save and tutor local start and the Discovery service should have the new value for buffer-size.

## Reviewers:

- [x] @anfbermudezme 