### PR TITLE
PADV-2693 feat: add UWSGI_BUFFER_SIZE to set the buffer-size in the Discovery image.

### DIFF
--- a/tutordiscovery/plugin.py
+++ b/tutordiscovery/plugin.py
@@ -43,6 +43,7 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
         "ELASTICSEARCH_PORT": 9200,
         "ELASTICSEARCH_SCHEME": "http",
         "ELASTICSEARCH_HEAP_SIZE": "1g",
+        "UWSGI_BUFFER_SIZE": "8192",
     },
     "unique": {
         "MYSQL_PASSWORD": "{{ 8|random_string }}",

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -99,5 +99,5 @@ CMD ["uwsgi", \
     "--single-interpreter", \
     "--enable-threads", \
     "--processes=2", \
-    "--buffer-size=8192", \
+    "--buffer-size={{ DISCOVERY_UWSGI_BUFFER_SIZE }}", \
     "--wsgi-file", "course_discovery/wsgi.py"]


### PR DESCRIPTION
## Description:

This PR support the custom change to adds the capability to set the [buffer-size](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size) for the UWSGI process in the Discovery image in ulmo version.

## Changes Made

* Cherry pick from https://github.com/Pearson-Advance/tutor-discovery/pull/2/commits/aaf20d42162717fb66a823e84bd38ba77594273a

## How to test:

- With Discovery Tutor plugin enabled, run ``tutor config save``.
- The rendered Dockerfile: ``env/plugins/discovery/build/discovery/Dockerfile`` should have the default value of 8192.
- Add ``DISCOVERY_UWSGI_BUFFER_SIZE`` to the __config.yaml__ with another value, e.i 20000.
- Run ``tutor config save`` and the Dockerfile should now have the value set from the __config.yaml__.
- Run ``tutor images build discovery`` and the image should be built without any errors.
- Run ``tutor config save`` and ``tutor local start`` and the Discovery service should have the new value for buffer-size.

## Issue

* https://pearson.atlassian.net/browse/PADV-2693